### PR TITLE
remove blits by using an other array of the same size

### DIFF
--- a/src/lib/array/timsort.ml
+++ b/src/lib/array/timsort.ml
@@ -90,89 +90,52 @@ let rec merge_lo
       src1 (ofs1 + 1) (len1 - 1)
   end
 
-
-let rec merge_hi
-  cmp
-  dest ofs
-  src0 ofs0 len0
-  src1 ofs1 len1
-=
-  assert (Array.length dest >= ofs + len0 + len1);
-  assert (Array.length src0 >= ofs0 + len0);
-  assert (Array.length src1 >= ofs1 + len1);
-  assert (len0 >= 0);
-  assert (len1 >= 0);
-  if len0 = 0 then
-    Array.blit src1 ofs1 dest ofs len1
-  else if len1 = 0 then
-    Array.blit src0 ofs0 dest ofs len0
-  else if cmp src0.(ofs0 + len0 - 1) src1.(ofs1 + len1 - 1) <= 0 then begin
-    dest.(ofs + len0 + len1 - 1) <- src1.(ofs1 + len1 - 1);
-    merge_hi
-      cmp
-      dest ofs
-      src0 ofs0 len0
-      src1 ofs1 (len1 - 1)
-  end else begin
-    dest.(ofs + len0 + len1 - 1) <- src0.(ofs0 + len0 - 1);
-    merge_hi
-      cmp
-      dest ofs
-      src0 ofs0 (len0 - 1)
-      src1 ofs1 len1
-  end
-
-
-let merge ~buffer cmp t (ofs0, len0) (ofs1, len1) =
+let merge ~buffer cmp t (src0, ofs0, len0) (src1, ofs1, len1) =
   assert (ofs0 + len0 = ofs1);
   assert (ofs1 + len1 <= Array.length t);
-  if len0 < len1 then begin
-    Array.blit t ofs0 buffer 0 len0;
-    merge_lo
-      cmp
-      t ofs0
-      buffer 0 len0
-      t ofs1 len1
-  end else begin
-    Array.blit t ofs1 buffer 0 len1;
-    merge_hi
-      cmp
-      t ofs0
-      t ofs0 len0
-      buffer 0 len1
-  end;
-  ofs0, len0 + len1
+  let dest =
+    if src0 == src1 then
+      if src0 == t then buffer else t
+    else
+      src1
+  in
+  merge_lo
+    cmp
+    dest ofs0
+    src0 ofs0 len0
+    src1 ofs1 len1;
+  (dest, ofs0, len0 + len1)
 
 let rec merge_all ~buffer cmp t = function
   | [] ->
     assert (t = [||]);
     ()
-  | [(ofs, len)] ->
+  | [(src, ofs, len)] ->
     assert (ofs = 0);
     assert (len = Array.length t);
-    ()
+    if src == buffer then
+      Array.blit buffer 0 t 0 len
   | r0 :: r1 :: stack ->
     merge_all ~buffer cmp t (merge ~buffer cmp t r1 r0 :: stack)
 
 let timsort (cmp: 'a cmp) (t: 'a array) =
   let t_len = Array.length t in
-  (* Merge buffer: when merging two adjacent runs, the smallest one is moved to
-   * this temporary buffer and the merging happens in the main array. *)
   let buffer =
-    if t_len > 2 then Array.make (t_len / 2) t.(0)
+    if t_len > 0 then Array.make t_len t.(0)
     else [||]
   in
+
   let merge = merge ~buffer cmp t in
   let merge_all = merge_all ~buffer cmp t in
   let next_run = next_run cmp t in
 
-  let rec sort offset (stack0 : (int * int) list) =
+  let rec sort offset (stack0 : ('a array * int * int) list) =
     (* stackn = stack starting with rn *)
     match stack0 with
-    | ((_, len0) as r0) :: (((_, len1) as r1) :: stack2) ->
+    | ((_, _, len0) as r0) :: (((_, _, len1) as r1) :: stack2) ->
       (
         match stack2 with
-        | ((_, len2) as r2) :: stack3 ->
+        | ((_, _, len2) as r2) :: stack3 ->
           (
             if len2 < len0 then
               sort offset (r0 :: merge r2 r1 :: stack3)
@@ -182,13 +145,13 @@ let timsort (cmp: 'a cmp) (t: 'a array) =
               sort offset (merge r1 r0 :: stack2)
             else
               match stack3 with
-              | (_, len3) :: _ when len3 <= len2 + len1 ->
+              | (_, _, len3) :: _ when len3 <= len2 + len1 ->
                 sort offset (merge r1 r0 :: stack2)
 
               | _ ->
                 if offset < t_len then
                   let len = next_run offset in
-                  sort (offset + len) ((offset, len) :: stack0)
+                  sort (offset + len) ((t, offset, len) :: stack0)
                 else
                   merge_all stack0
           )
@@ -197,7 +160,7 @@ let timsort (cmp: 'a cmp) (t: 'a array) =
             sort offset (merge r1 r0 :: stack2)
           else if offset < t_len then
             let len = next_run offset in
-            sort (offset + len) ((offset, len) :: stack0)
+            sort (offset + len) ((t, offset, len) :: stack0)
           else
             merge_all stack0
       )
@@ -205,7 +168,7 @@ let timsort (cmp: 'a cmp) (t: 'a array) =
     | _ ->
       if offset < t_len then
         let len = next_run offset in
-        sort (offset + len) ((offset, len) :: stack0)
+        sort (offset + len) ((t, offset, len) :: stack0)
       else
         merge_all stack0
   in


### PR DESCRIPTION
In this PR, I use a buffer of the same size as the array. Runs carry (in addition to offset and length) a source array. When merging two runs, one can always find an array (either the initial one or the buffer) in which to merge them using only merge_lo and without blit. At the end, everything is in the same array, possibly the buffer.

Before
![image](https://user-images.githubusercontent.com/5920602/115706480-fd37fe00-a36d-11eb-9451-efc788279bca.png)

After
![image](https://user-images.githubusercontent.com/5920602/115706496-01641b80-a36e-11eb-9659-108c6389e7ae.png)
